### PR TITLE
Introduce the optional variable MANAGED_CLUSTER_CONTEXT_NAME in import-managedcluster role

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,14 @@ CURRENT   NAME        CLUSTER                 AUTHINFO    NAMESPACE
 ```
 
 ```shell
+# This playbook execution makes the assumption that the name of the cluster imported in RH ACM is equal to the managed cluster context name
 (ansible-env)$ ansible-playbook import-cluster.yml -e MANAGED_CLUSTER_NAME=managed-1
-[.... skipped for brevrity ... ] 
-(ansible-env)$ ansible-playbook import-cluster.yml -e MANAGED_CLUSTER_NAME=managed-2
-[.... skipped for brevrity ... ] 
+[.... skipped for brevrity ... ]
+
+# This playbook execution allow to define a name(defined in the variable MANAGED_CLUSTER_NAME) for the imported managed cluster different by its cluster context name(defined in the variable MANAGED_CLUSTER_CONTEXT_NAME)
+# The variable MANAGED_CLUSTER_CONTEXT_NAME is optional
+(ansible-env)$ ansible-playbook import-cluster.yml -e MANAGED_CLUSTER_NAME=managed-2 -e MANAGED_CLUSTER_CONTEXT_NAME=cluster-context-managed-2
+[.... skipped for brevrity ... ]
 ```
 
 After the commands above your clusters should be imported and available

--- a/roles/import-managedcluster/tasks/main.yml
+++ b/roles/import-managedcluster/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Define MANAGED_CLUSTER_CONTEXT_NAME equal to MANAGED_CLUSTER_NAME if it is not provided by the user
+  set_fact:
+    MANAGED_CLUSTER_CONTEXT_NAME: "{{ MANAGED_CLUSTER_NAME }}"
+  when: MANAGED_CLUSTER_CONTEXT_NAME is not defined
 
 - name: Verify ACM Hub cluster connection
   kubernetes.core.k8s_cluster_info:
@@ -8,7 +12,7 @@
 
 - name: Verify managed cluster connection
   kubernetes.core.k8s_cluster_info:
-    context: "{{ MANAGED_CLUSTER_NAME }}"
+    context: "{{ MANAGED_CLUSTER_CONTEXT_NAME }}"
     invalidate_cache: False
   register: api_status
 
@@ -51,14 +55,14 @@
 
 - name: Inject import CRDs into {{ MANAGED_CLUSTER_NAME }}
   kubernetes.core.k8s:
-    context: "{{ MANAGED_CLUSTER_NAME }}"
+    context: "{{ MANAGED_CLUSTER_CONTEXT_NAME }}"
     state: present
     template:
       - path: "{{ crd_import_tmp.path }}"
 
 - name: Inject import command into {{ MANAGED_CLUSTER_NAME }}
   kubernetes.core.k8s:
-    context: "{{ MANAGED_CLUSTER_NAME }}"
+    context: "{{ MANAGED_CLUSTER_CONTEXT_NAME }}"
     state: present
     template:
       - path: "{{ import_import_tmp.path }}"


### PR DESCRIPTION
This commit allow to generalize the role import-managedcluster.
Before this commit the context name and the name showed in RHACM of the imported managed cluster must be the same because specified by the single variable MANAGED_CLUSTER_NAME.

In real world examples the context name could contain prefixes or suffixes that the user doesn't want include in the name of the cluster imported in the managed cluster.

In this commit I modified the role to accept from the user an optional variable MANAGED_CLUSTER_CONTEXT_NAME that allow to define the managed cluster context name when it is different by the name of the cluster that the user wants show in RH ACM (defined in the variable MANAGED_CLUSTER_NAME).

MANAGED_CLUSTER_CONTEXT_NAME is an optional variable in order to guarantee backward-compatibility with the previous version of this role.
When MANAGED_CLUSTER_CONTEXT_NAME is not defined there is an ansible role task that assign the value of MANAGED_CLUSTER_NAME to MANAGED_CLUSTER_CONTEXT_NAME.

After this commit,  two different way to call the import_playbook will be valid:

1. The already existing way to import cluster:

```
# This playbook execution makes the assumption that the name of the cluster imported in RH ACM is equal to the managed cluster context name
(ansible-env)$ ansible-playbook import-cluster.yml -e MANAGED_CLUSTER_NAME=managed-1
```

2. The change introduced in this commit that allow to define a MANAGED_CLUSTER_NAME different from MANAGED_CLUSTER_CONTEXT_NAME:

``` 
# This playbook execution allow to define a name(defined in the variable MANAGED_CLUSTER_NAME) for the imported managed cluster different by its cluster context name(defined in the variable MANAGED_CLUSTER_CONTEXT_NAME)
# The variable MANAGED_CLUSTER_CONTEXT_NAME is optional
(ansible-env)$ ansible-playbook import-cluster.yml -e MANAGED_CLUSTER_NAME=managed-2 -e MANAGED_CLUSTER_CONTEXT_NAME=cluster-context-managed-2
```
